### PR TITLE
Including correct role when updating a user

### DIFF
--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -87,13 +87,15 @@ class UserService:
     @classmethod
     async def update(cls, session: AsyncSession, user_id: UUID, update_data: Dict[str, str]) -> Optional[User]:
         try:
-            # validated_data = UserUpdate(**update_data).dict(exclude_unset=True)
+            logger.info(f"Attempting to update user with ID: {user_id}")
             validated_data = UserUpdate(**update_data).dict(exclude_unset=True)
-
+            logger.debug(f"Validated update data: {validated_data}")
             if 'password' in validated_data:
                 validated_data['hashed_password'] = hash_password(validated_data.pop('password'))
+                logger.debug("Password was updated")
             query = update(User).where(User.id == user_id).values(**validated_data).execution_options(synchronize_session="fetch")
             await cls._execute_query(session, query)
+            logger.debug("Update query executed successfully")
             updated_user = await cls.get_by_id(session, user_id)
             if updated_user:
                 session.refresh(updated_user)  # Explicitly refresh the updated user object


### PR DESCRIPTION
## Description
This pull request addresses the issue of incorrect role information being returned in the response body when updating a user. The changes ensure that the response includes the accurate role from the database and adds logging to improve visibility and debugging.

## Changes made

- Fixed the issue where the role in the response body did not match the role in the database when updating a user.
- Added logging to:
  - Record the request to update a user and log the user ID.
  - Debug the user data that will be updated.
  - Indicate a successful update or when a user is not found.
  - Track the validation of update data and indicate when the password is updated.
  - Debug the successful execution of the update query.
  - Indicate errors during the update process.